### PR TITLE
Skip compiling example file as it's failing on Erlang 24

### DIFF
--- a/src/passage_example.erl
+++ b/src/passage_example.erl
@@ -3,7 +3,7 @@
 %% @private
 -module(passage_example).
 
--compile({parse_transform, passage_transform}).
+%% -compile({parse_transform, passage_transform}).
 
 %%------------------------------------------------------------------------------
 %% Exported API
@@ -13,7 +13,7 @@
 %%------------------------------------------------------------------------------
 %% Exported Functions
 %%------------------------------------------------------------------------------
--passage_trace([{tags, #{kind => "greeting", name => "Name"}}]).
+%%-passage_trace([{tags, #{kind => "greeting", name => "Name"}}]).
 -spec hello(atom()) -> ok.
 hello(Name) ->
     io:format("Hello ~s\n", [Name]),
@@ -24,7 +24,7 @@ hello(Name) ->
 %%------------------------------------------------------------------------------
 %% Internal Functions
 %%------------------------------------------------------------------------------
--passage_trace([{error_if, "{error, _}"}, error_if_exception]).
+%%-passage_trace([{error_if, "{error, _}"}, error_if_exception]).
 -spec hello_child(atom()) -> {ok, passage:maybe_span()} | {error, term()}.
 hello_child(Name) ->
     case Name of
@@ -35,8 +35,8 @@ hello_child(Name) ->
             {ok, passage_pd:current_span()}
     end.
 
--passage_trace([{follows_from, "Span"}]).
+%%-passage_trace([{follows_from, "Span"}]).
 -spec hello_sibling(passage:maybe_span(), atom()) -> ok.
-hello_sibling(Span, Name) ->
+hello_sibling(_Span, Name) ->
     io:format("[sibling] Hello ~s\n", [Name]),
     ok.


### PR DESCRIPTION
Failure looks like:
```
passage/src/passage_example.erl:none:
   error in parse transform 'passage_transform': {badarg,
     [{erlang,integer_to_list,
       [{18,1}],
       [{error_info,
         #{module =>
            erl_erts_errors}}]},
      {passage_transform,make_var,
       2,
       [{file,
         "src/passage_transform.erl"},
        {line,282}]},
      {passage_transform,
       make_catch_clauses,2,
```